### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@
        ```sh 
        $ cd ~/catkin_ws/src/vive_ros
        $ sudo cp ./60-HTC-Vive-perms.rules /etc/udev/rules.d
-       $ sudo udevadm --reload-rules && sudo udevadm trigger
+       $ sudo udevadm control --reload-rules && sudo udevadm trigger
        ```               
 - ### Steam and SteamVR installation:
     1. #### Download [Steam](https://store.steampowered.com) latest version. You should get the file steam_latest.deb in your ~/Downloads folder


### PR DESCRIPTION
Thank you for the helpful documentation!  
When I ran `$ sudo udevadm --reload-rules && sudo udevadm trigger`, I got the following error.
```
$ sudo udevadm --reload-rules && sudo udevadm trigger
udevadm: unrecognized option '--reload-rules'
```
Same as [the original branch README](https://github.com/robosavvy/vive_ros#allow-hardware-access ), I think the following is correct for this part.  
```
$ sudo udevadm control --reload-rules && sudo udevadm trigger
```